### PR TITLE
Add Configurability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+Serial HDMI Switcher
+=====
+
+Introduction
+----
+
+This is a library that uses the `serialport` to control various HDMI switchers. Primary use currently is for a library for (Homebridge)[https://github.com/emptygalaxy/homebridge-hdmi-switch].
+
+Building
+---
+
+1. Run `npm install` in the root of the directory.
+2. Run `npm run build`
+
+Testing
+---
+
+1. Ensure that your configuration is correct in test.js
+2. Run `node test.js`
+3. Observe HDMI Switcher
+
+Usage
+---
+
+### Simple
+
+```ts
+let device: HDMISwitch = new HDMISwitch('/dev/cu.usbserial-145420')
+device.setInputIndex(1);
+```
+
+### Complex
+
+You can also supply a options object to the constructor to customize the behavior of the switcher.
+
+The following example is for a Xantech XT-SW41-4K18G:
+
+```
+new HDMISwitch(
+    '/dev/cu.usbserial-145420',
+    {
+        Baud: 57600,
+        ZeroIndexed: false,
+        CommandEnd: '\r',
+        MaxInputs: 4,
+        Commands: {
+            PowerOn: 'OUTON',
+            PowerOff: 'OUTOFF',
+            OutputSelect: 'OUT FR %d',
+        }
+    }
+);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,6 +545,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
   },
   "main": "dist/HDMISwitch.js",
   "types": "dist/HDMISwitch.d.ts",
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "^4.4.4"
+  },
   "scripts": {
-    "test": "dist/test.js"
+    "test": "dist/test.js",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,6 +1,23 @@
 import {HDMISwitch, Source} from "./HDMISwitch";
 
-let device:HDMISwitch = new HDMISwitch('/dev/cu.usbserial-40130');
+const ComplicatedExample = () => new HDMISwitch(
+    '/dev/cu.usbserial-145420',
+    {
+        Baud: 57600,
+        ZeroIndexed: false,
+        CommandEnd: '\r',
+        MaxInputs: 4,
+        Commands: {
+            PowerOn: 'OUTON',
+            PowerOff: 'OUTOFF',
+            OutputSelect: 'OUT FR %d',
+        }
+    }
+);
+
+// Simple Example
+let device:HDMISwitch = new HDMISwitch('/dev/cu.usbserial-145420')
+
 let currentInput = 0;
 
 setTimeout(() => {
@@ -11,7 +28,7 @@ setTimeout(() => {
 
         setInterval(()=>{
             currentInput ++;
-            currentInput %= 5;
+            currentInput %= device.options.MaxInputs;
 
             device.setInputIndex(currentInput);
         }, 10000);


### PR DESCRIPTION
Ended up using the HDMI Switcher Homebridge that this uses, but noticed a lot of things were hard coded. 

So here are the changes:
- Added an Options object for the constructor as well as default values for backwards compatibility.
- Added typescript as a dev dependency so developers won't need to have a global package to build the repo.
- Added a basic readme
- Added a complex example specifying all options.

I was able to make the test work on my HDMI switcher with the complex example since my commands and baud were drastically different, but otherwise seems to work as previous.

I will also have another MR for the homebridge repo that uses this as well to ensure it's baud config is actually passed and to open up the ability to specify the commands from HomeBridge X GUI.